### PR TITLE
Update environment.yml for latest GPUs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,8 @@ dependencies:
   - pillow
   - opencv
   - pip:
-      - --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126
+    - --index-url https://download.pytorch.org/whl/nightly/cu128
+    - --pre 
+    - torch
+    - torchvision 
+    - torchaudio  


### PR DESCRIPTION
Should list out pip line by line. Apparently, doing it all in one line can cause issues with the dependencies not being downloaded according to the stipulated index-url versions.

To check if older GPUs like 1060 can still work.

To check if other GPUs are compatible with this (eg. non CUDA ones from ATI.). May have to consider different environment.yml setups depending on GPU.